### PR TITLE
Remove the | operator that results in a stack overflow when used in a pattern.

### DIFF
--- a/re.c
+++ b/re.c
@@ -38,7 +38,7 @@
 #define MAX_CHAR_CLASS_LEN      40    /* Max length of character-class buffer in.   */
 
 
-enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, CHAR, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE, BRANCH };
+enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, CHAR, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE };
 
 typedef struct regex_t
 {
@@ -123,7 +123,6 @@ re_t re_compile(const char* pattern)
       case '*': {    re_compiled[j].type = STAR;            } break;
       case '+': {    re_compiled[j].type = PLUS;            } break;
       case '?': {    re_compiled[j].type = QUESTIONMARK;    } break;
-      case '|': {    re_compiled[j].type = BRANCH;          } break;
 
       /* Escaped character-classes (\s \w ...): */
       case '\\':
@@ -208,7 +207,7 @@ re_t re_compile(const char* pattern)
 
 void re_print(regex_t* pattern)
 {
-  const char* types[] = { "UNUSED", "DOT", "BEGIN", "END", "QUESTIONMARK", "STAR", "PLUS", "CHAR", "CHAR_CLASS", "INV_CHAR_CLASS", "DIGIT", "NOT_DIGIT", "ALPHA", "NOT_ALPHA", "WHITESPACE", "NOT_WHITESPACE", "BRANCH" };
+  const char* types[] = { "UNUSED", "DOT", "BEGIN", "END", "QUESTIONMARK", "STAR", "PLUS", "CHAR", "CHAR_CLASS", "INV_CHAR_CLASS", "DIGIT", "NOT_DIGIT", "ALPHA", "NOT_ALPHA", "WHITESPACE", "NOT_WHITESPACE" };
 
   int i;
   for (i = 0; i < MAX_REGEXP_OBJECTS; ++i)
@@ -416,10 +415,6 @@ static int matchpattern(regex_t* pattern, const char* text)
     else if ((pattern[0].type == END) && pattern[1].type == UNUSED)
     {
       return (text[0] == '\0');
-    }
-    else if (pattern[1].type == BRANCH)
-    {
-      return (matchpattern(pattern, text) || matchpattern(&pattern[2], text));
     }
   }
   while ((text[0] != '\0') && matchone(*pattern++, *text++));

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -60,6 +60,7 @@ char* test_vector[][3] =
   { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world!   " },
   { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world  !" },
   { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "hello World    !" },
+  { OK,  "0|",           "0|"              },
 /*
   { OK,  "[^\\w][^-1-4]",     ")T"          },
   { OK,  "[^\\w][^-1-4]",     ")^"          },


### PR DESCRIPTION
This bug was found by AFL (input: "0|").