### PR TITLE
Check for correct python2 binary in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@ CC := gcc
 # Number of random text expressions to generate, for random testing
 NRAND_TESTS := 1000
 
+PYTHON != if (python --version 2>&1 | grep -q 'Python 2\..*'); then \
+            echo 'python';                                          \
+          elif command -v python2 >/dev/null 2>&1; then             \
+            echo 'python2';                                         \
+          else                                                      \
+            echo 'Error: no compatible python version found.' >&2;  \
+            exit 1;                                                 \
+          fi
 
 # Flags to pass to compiler
 CFLAGS := -O3 -Wall -Wextra -std=c99 -I.
@@ -22,73 +30,74 @@ clean:
 
 
 test: all
+	@$(test $(PYTHON))
 	@echo
 	@echo Testing hand-picked regex\'s:
 	@./tests/test1
 	@echo Testing patterns against $(NRAND_TESTS) random strings matching the Python implementation and comparing:
 	@echo
-	@python ./scripts/regex_test.py \\d+\\w?\\D\\d             $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\w*\\d?\\w\\?             $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^\\d]+\\\\?\\s            $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^\\w][^-1-4]              $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^\\w]                     $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^1-4]                     $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^\\d]+\\s?[\\w]*          $(NRAND_TESTS)
-	@python ./scripts/regex_test.py a+b*[ac]*.+.*.[\\.].       $(NRAND_TESTS)
-	@python ./scripts/regex_test.py a?b[ac*]*.?[\\]+[?]?       $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\d+\\w?\\D\\d             $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\w*\\d?\\w\\?             $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^\\d]+\\\\?\\s            $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^\\w][^-1-4]              $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^\\w]                     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^1-4]                     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^\\d]+\\s?[\\w]*          $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py a+b*[ac]*.+.*.[\\.].       $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py a?b[ac*]*.?[\\]+[?]?       $(NRAND_TESTS)
 	@#python ./scripts/regex_test.py [1-5-]+[-1-2]-[-]         $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [-1-3]-[-]+                $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [1-5]+[-1-2]-[\\-]         $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [-1-2]*                    $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\s?[a-fKL098]+-?          $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [\\-]*                     $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [\\\\]+                    $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [0-9a-fA-F]+               $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [1379][2468][abcdef]       $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [012345-9]?[0123-789]      $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [012345-9]                 $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [0-56789]                  $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [abc-zABC-Z]               $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [a\d]?1234                 $(NRAND_TESTS)
-	@python ./scripts/regex_test.py .*123faerdig               $(NRAND_TESTS)
-	@python ./scripts/regex_test.py .?\\w+jsj$                 $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [?to][+to][?ta][*ta]       $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\d+                       $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [a-z]+                     $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\w                        $(NRAND_TESTS)
-	@python ./scripts/regex_test.py \\d                        $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [\\d]                      $(NRAND_TESTS)
-	@python ./scripts/regex_test.py [^\\d]                     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [-1-3]-[-]+                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [1-5]+[-1-2]-[\\-]         $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [-1-2]*                    $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\s?[a-fKL098]+-?          $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [\\-]*                     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [\\\\]+                    $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [0-9a-fA-F]+               $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [1379][2468][abcdef]       $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [012345-9]?[0123-789]      $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [012345-9]                 $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [0-56789]                  $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [abc-zABC-Z]               $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [a\d]?1234                 $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py .*123faerdig               $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py .?\\w+jsj$                 $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [?to][+to][?ta][*ta]       $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\d+                       $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [a-z]+                     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\w                        $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py \\d                        $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [\\d]                      $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test.py [^\\d]                     $(NRAND_TESTS)
 	@#python ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
 	@echo
 	@echo
 	@echo
 	@echo Testing rejection of patterns against $(NRAND_TESTS) random strings also rejected by the Python implementation:
 	@echo
-	@python ./scripts/regex_test_neg.py \\d+                   $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [a-z]+                 $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py \\s+[a-zA-Z0-9?]*      $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py ^\\w                   $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py ^\\d                   $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [\\d]                  $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py ^[^\\d]                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [^\\w]+                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py ^[\\w]+                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py ^[^0-9]                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [a-z].[A-Z]            $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [-1-3]-[-]+            $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [1-5]+[-1-2]-[\\-]     $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [-0-9]+                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [\\-]+                 $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [\\\\]+                $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [0-9a-fA-F]+           $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [1379][2468][abcdef]   $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [012345-9]             $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py [0-56789]              $(NRAND_TESTS)
-	@python ./scripts/regex_test_neg.py .*123faerdig           $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py \\d+                   $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [a-z]+                 $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py \\s+[a-zA-Z0-9?]*      $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py ^\\w                   $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py ^\\d                   $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [\\d]                  $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py ^[^\\d]                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [^\\w]+                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py ^[\\w]+                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py ^[^0-9]                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [a-z].[A-Z]            $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [-1-3]-[-]+            $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [1-5]+[-1-2]-[\\-]     $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [-0-9]+                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [\\-]+                 $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [\\\\]+                $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [0-9a-fA-F]+           $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [1379][2468][abcdef]   $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [012345-9]             $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py [0-56789]              $(NRAND_TESTS)
+	$(PYTHON) ./scripts/regex_test_neg.py .*123faerdig           $(NRAND_TESTS)
 	@echo
 	@echo
 	@./tests/test2

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,14 @@ CC := gcc
 # Number of random text expressions to generate, for random testing
 NRAND_TESTS := 1000
 
-PYTHON := python
-# PYTHON != if (python --version 2>&1 | grep -q 'Python 2\..*'); then \
-#             echo 'python';                                          \
-#           elif command -v python2 >/dev/null 2>&1; then             \
-#             echo 'python2';                                         \
-#           else                                                      \
-#             echo 'Error: no compatible python version found.' >&2;  \
-#             exit 1;                                                 \
-#           fi
+PYTHON != if (python --version 2>&1 | grep -q 'Python 2\..*'); then \
+            echo 'python';                                          \
+          elif command -v python2 >/dev/null 2>&1; then             \
+            echo 'python2';                                         \
+          else                                                      \
+            echo 'Error: no compatible python version found.' >&2;  \
+            exit 1;                                                 \
+          fi
 
 # Flags to pass to compiler
 CFLAGS := -O3 -Wall -Wextra -std=c99 -I.
@@ -37,68 +36,68 @@ test: all
 	@./tests/test1
 	@echo Testing patterns against $(NRAND_TESTS) random strings matching the Python implementation and comparing:
 	@echo
-	$(PYTHON) ./scripts/regex_test.py \\d+\\w?\\D\\d             $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\w*\\d?\\w\\?             $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^\\d]+\\\\?\\s            $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^\\w][^-1-4]              $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^\\w]                     $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^1-4]                     $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^\\d]+\\s?[\\w]*          $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py a+b*[ac]*.+.*.[\\.].       $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py a?b[ac*]*.?[\\]+[?]?       $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\d+\\w?\\D\\d             $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\w*\\d?\\w\\?             $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^\\d]+\\\\?\\s            $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^\\w][^-1-4]              $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^\\w]                     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^1-4]                     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^\\d]+\\s?[\\w]*          $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py a+b*[ac]*.+.*.[\\.].       $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py a?b[ac*]*.?[\\]+[?]?       $(NRAND_TESTS)
 	@#python ./scripts/regex_test.py [1-5-]+[-1-2]-[-]         $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [-1-3]-[-]+                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [1-5]+[-1-2]-[\\-]         $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [-1-2]*                    $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\s?[a-fKL098]+-?          $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [\\-]*                     $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [\\\\]+                    $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [0-9a-fA-F]+               $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [1379][2468][abcdef]       $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [012345-9]?[0123-789]      $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [012345-9]                 $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [0-56789]                  $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [abc-zABC-Z]               $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [a\d]?1234                 $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py .*123faerdig               $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py .?\\w+jsj$                 $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [?to][+to][?ta][*ta]       $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\d+                       $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [a-z]+                     $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\w                        $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py \\d                        $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [\\d]                      $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test.py [^\\d]                     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [-1-3]-[-]+                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [1-5]+[-1-2]-[\\-]         $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [-1-2]*                    $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\s?[a-fKL098]+-?          $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [\\-]*                     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [\\\\]+                    $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [0-9a-fA-F]+               $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [1379][2468][abcdef]       $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [012345-9]?[0123-789]      $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [012345-9]                 $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [0-56789]                  $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [abc-zABC-Z]               $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [a\d]?1234                 $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py .*123faerdig               $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py .?\\w+jsj$                 $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [?to][+to][?ta][*ta]       $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\d+                       $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [a-z]+                     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\s+[a-zA-Z0-9?]*          $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\w                        $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py \\d                        $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [\\d]                      $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test.py [^\\d]                     $(NRAND_TESTS)
 	@#python ./scripts/regex_test.py [^-1-4]                    $(NRAND_TESTS)
 	@echo
 	@echo
 	@echo
 	@echo Testing rejection of patterns against $(NRAND_TESTS) random strings also rejected by the Python implementation:
 	@echo
-	$(PYTHON) ./scripts/regex_test_neg.py \\d+                   $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [a-z]+                 $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py \\s+[a-zA-Z0-9?]*      $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py ^\\w                   $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py ^\\d                   $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [\\d]                  $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py ^[^\\d]                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [^\\w]+                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py ^[\\w]+                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py ^[^0-9]                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [a-z].[A-Z]            $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [-1-3]-[-]+            $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [1-5]+[-1-2]-[\\-]     $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [-0-9]+                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [\\-]+                 $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [\\\\]+                $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [0-9a-fA-F]+           $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [1379][2468][abcdef]   $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [012345-9]             $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py [0-56789]              $(NRAND_TESTS)
-	$(PYTHON) ./scripts/regex_test_neg.py .*123faerdig           $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py \\d+                   $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [a-z]+                 $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py \\s+[a-zA-Z0-9?]*      $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py ^\\w                   $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py ^\\d                   $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [\\d]                  $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py ^[^\\d]                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [^\\w]+                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py ^[\\w]+                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py ^[^0-9]                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [a-z].[A-Z]            $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [-1-3]-[-]+            $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [1-5]+[-1-2]-[\\-]     $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [-0-9]+                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [\\-]+                 $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [\\\\]+                $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [0-9a-fA-F]+           $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [1379][2468][abcdef]   $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [012345-9]             $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py [0-56789]              $(NRAND_TESTS)
+	@$(PYTHON) ./scripts/regex_test_neg.py .*123faerdig           $(NRAND_TESTS)
 	@echo
 	@echo
 	@./tests/test2

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,15 @@ CC := gcc
 # Number of random text expressions to generate, for random testing
 NRAND_TESTS := 1000
 
-PYTHON != if (python --version 2>&1 | grep -q 'Python 2\..*'); then \
-            echo 'python';                                          \
-          elif command -v python2 >/dev/null 2>&1; then             \
-            echo 'python2';                                         \
-          else                                                      \
-            echo 'Error: no compatible python version found.' >&2;  \
-            exit 1;                                                 \
-          fi
+PYTHON := python
+# PYTHON != if (python --version 2>&1 | grep -q 'Python 2\..*'); then \
+#             echo 'python';                                          \
+#           elif command -v python2 >/dev/null 2>&1; then             \
+#             echo 'python2';                                         \
+#           else                                                      \
+#             echo 'Error: no compatible python version found.' >&2;  \
+#             exit 1;                                                 \
+#           fi
 
 # Flags to pass to compiler
 CFLAGS := -O3 -Wall -Wextra -std=c99 -I.


### PR DESCRIPTION
Re: issue #13

I decided to go ahead and make that little change, and do it just a wee bit smarter than blindly replacing all instances of `python` with `python2`, which can't be considered portable. This little shell function should detect which name python2 goes by on a system, and fails if it isn't found. It is notable that this means the whole compilation will fail if python2 isn't found. I doubt this would be a big issue since the build only exists in the first place to run the tests, which require python2. And really, if your version of python is broken you have far more serious concerns for your system than messing around with regular expression libraries!

Anyway, maybe also worth noting that truly ancient (read: pre 1990) shells do not understand the "command -v" command. If anyone is using such a shell then this will fail. I recommend that any such person report to the nearest museum for permanent display.

Jokes aside, this tiny little fix should work with any sensible version of make and any halfway sensible shell, and mostly resolves the issue of finding the right python.

EDIT: Eugh. I should really learn to double check things before I make pull requests. I changed a few values to test the changes and forgot to change them back. Everything is ok now. Sorry about that.