### PR TITLE
Added match length support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,33 +20,19 @@ I think you should test the patterns you are going to use. You can easily modify
 The main design goal of this library is to be small, correct, self contained and use few resources while retaining acceptable performance and feature completeness. Clarity of the code is also highly valued.
 
 ### Notable features and omissions
-- Small code and binary size: <500 SLOC, ~3kb binary for x86. Statically #define'd memory usage / allocation.
+- Small code and binary size: 500 SLOC, ~3kb binary for x86. Statically #define'd memory usage / allocation.
 - No use of dynamic memory allocation (i.e. no calls to `malloc` / `free`).
 - To avoid call-stack exhaustion, iterative searching is preferred over recursive by default (can be changed with a pre-processor flag).
 - No support for capturing groups or named capture: `(^P<name>group)` etc.
 - Thorough testing : [exrex](https://github.com/asciimoo/exrex) is used to randomly generate test-cases from regex patterns, which are fed into the regex code for verification. Try `make test` to generate a few thousand tests cases yourself.
-- Compiled for x86 using GCC 4.7.4 and optimizing for size, the binary takes up ~2-3kb code space and allocates ~0.5kb RAM :
+- Provides character length of matches.
+- Compiled for x86 using GCC 7.2.0 and optimizing for size, the binary takes up ~2-3kb code space and allocates ~0.5kb RAM :
   ```
   > gcc -Os -c re.c
   > size re.o
       text     data     bss     dec     hex filename
-      2319        0     544    2863     b2f re.o
+      2440      160     544    3144     c48 re.o
       
-  ```
-  For ARM/Thumb using GCC 4.8.1 it's around 1.5kb code and less RAM :
-  ```
-  > arm-none-eabi-gcc -Os -mthumb -c re.c
-  > size re.o
-      text     data     bss     dec     hex filename
-      1418        0     280    1698     6a2 re.o
-
-  ```
-  For 8-bit AVR using AVR-GCC 4.8.1 it's around 2kb code and less RAM :
-  ```
-  > avr-gcc -Os -c re.c
-  > size re.o
-      text     data     bss     dec     hex filename
-      2128        0     130    2258     8d2 re.o
   ```
 
 
@@ -61,10 +47,10 @@ typedef struct regex_t* re_t;
 re_t re_compile(const char* pattern);
 
 /* Finds matches of the compiled pattern inside text. */
-int  re_matchp(re_t pattern, const char* text);
+int  re_matchp(re_t pattern, const char* text, int* matchlength);
 
 /* Finds matches of pattern inside text (compiles first automatically). */
-int  re_match(const char* pattern, const char* text);
+int  re_match(const char* pattern, const char* text, int* matchlength);
 ```
 
 ### Supported regex-operators
@@ -97,11 +83,14 @@ Search a text-string for a regex and get an index into the string, using `re_mat
 
 The returned index points to the first place in the string, where the regex pattern matches.
 
+The integer pointer passed will hold the length of the match.
+
 If the regular expression doesn't match, the matching function returns an index of -1 to indicate failure.
 
 ### Examples
 Example of usage:
 ```C
+/* Standard int to hold length of match */
 /* Standard null-terminated C-string to search: */
 const char* string_to_search = "ahem.. 'hello world !' ..";
 
@@ -109,10 +98,10 @@ const char* string_to_search = "ahem.. 'hello world !' ..";
 re_t pattern = re_compile("[Hh]ello [Ww]orld\\s*[!]?");
 
 /* Check if the regex matches the text: */
-int match_idx = re_matchp(pattern, string_to_search);
+int match_idx = re_matchp(pattern, string_to_search, &match_length);
 if (match_idx != -1)
 {
-  printf("match at idx %d.\n", match_idx);
+  printf("match at idx %d, %i chars long.\n", match_idx, match_length);
 }
 ```
 
@@ -128,7 +117,7 @@ For more usage examples I encourage you to look at the code in the `tests`-folde
 ### FAQ
 - *Q: What differentiates this library from other C regex implementations?*
 
-  A: Well, the small size for one. <500 lines of C-code compiling to 2-3kb ROM, using very little RAM.
+  A: Well, the small size for one. 500 lines of C-code compiling to 2-3kb ROM, using very little RAM.
 
 ### License
 All material in this repository is in the public domain.

--- a/re.h
+++ b/re.h
@@ -42,11 +42,11 @@ re_t re_compile(const char* pattern);
 
 
 /* Find matches of the compiled pattern inside text. */
-int  re_matchp(re_t pattern, const char* text);
+int  re_matchp(re_t pattern, const char* text, int* matchlenght);
 
 
 /* Find matches of the txt pattern inside text (will compile automatically first). */
-int  re_match(const char* pattern, const char* text);
+int  re_match(const char* pattern, const char* text, int* matchlenght);
 
 
 #ifdef __cplusplus

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -11,82 +11,82 @@
 #define NOK   ((char*) 0)
 
 
-char* test_vector[][3] =
+char* test_vector[][4] =
 {
-  { OK,  "\\d",                       "5"                },
-  { OK,  "\\w+",                      "hej"              },
-  { OK,  "\\s",                       "\t \n"            },
-  { NOK, "\\S",                       "\t \n"            },
-  { OK,  "[\\s]",                     "\t \n"            },
-  { NOK, "[\\S]",                     "\t \n"            },
-  { NOK, "\\D",                       "5"                },
-  { NOK, "\\W+",                      "hej"              },
-  { OK,  "[0-9]+",                    "12345"            },
-  { OK,  "\\D",                       "hej"              },
-  { NOK, "\\d",                       "hej"              },
-  { OK,  "[^\\w]",                    "\\"               },
-  { OK,  "[\\W]",                     "\\"               },
-  { NOK, "[\\w]",                     "\\"               },
-  { OK,  "[^\\d]",                    "d"                },
-  { NOK, "[\\d]",                     "d"                },
-  { NOK, "[^\\D]",                    "d"                },
-  { OK,  "[\\D]",                     "d"                },
-  { OK,  "^.*\\\\.*$",                "c:\\Tools"        },
-  { OK,  "^[\\+-]*[\\d]+$",           "+27"              },
-  { OK,  "[abc]",                     "1c2"              },
-  { NOK, "[abc]",                     "1C2"              },
-  { OK,  "[1-5]+",                    "0123456789"       },
-  { OK,  "[.2]",                      "1C2"              },
-  { OK,  "a*$",                       "Xaa"              },
-  { OK,  "a*$",                       "Xaa"              },
-  { OK,  "[a-h]+",                    "abcdefghxxx"      },
-  { NOK, "[a-h]+",                    "ABCDEFGH"         },
-  { OK,  "[A-H]+",                    "ABCDEFGH"         },
-  { NOK, "[A-H]+",                    "abcdefgh"         },
-  { OK,  "[^\\s]+",                   "abc def"          },
-  { OK,  "[^fc]+",                    "abc def"          },
-  { OK,  "[^d\\sf]+",                 "abc def"          },
-  { OK,  "\n",                        "abc\ndef"         },
-  { OK,  "b.\\s*\n",                  "aa\r\nbb\r\ncc\r\n\r\n" },
-  { OK,  ".*c",                       "abcabc"           },
-  { OK,  ".+c",                       "abcabc"           },
-  { OK,  "[b-z].*",                   "ab"               },
-  { OK,  "b[k-z]*",                   "ab"               },
-  { NOK, "[0-9]",                     "  - "             },
-  { OK,  "[^0-9]",                    "  - "             },
-  { OK,  "0|",                        "0|"               },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "0s:00:00"         },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "000:00"           },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "00:0000"          },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "100:0:00"         },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "00:100:00"        },
-  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "0:00:100"         },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:0:0"            },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:00:0"           },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:0:00"           },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:0:0"           },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:00:0"          },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:0:00"          },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:00:00"          },
-  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:00:00"         },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world !"    },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "hello world !"    },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello World !"    },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world!   "  },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world  !"   },
-  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "hello World    !" },
-  { NOK, "\\d\\d?:\\d\\d?:\\d\\d?",   "a:0"              }, /* Failing test case reported in https://github.com/kokke/tiny-regex-c/issues/12 */
+  { OK,  "\\d",                       "5",                (char*) 1      },
+  { OK,  "\\w+",                      "hej",              (char*) 3      },
+  { OK,  "\\s",                       "\t \n",            (char*) 1      },
+  { NOK, "\\S",                       "\t \n",            (char*) 0      },
+  { OK,  "[\\s]",                     "\t \n",            (char*) 1      },
+  { NOK, "[\\S]",                     "\t \n",            (char*) 0      },
+  { NOK, "\\D",                       "5",                (char*) 0      },
+  { NOK, "\\W+",                      "hej",              (char*) 0      },
+  { OK,  "[0-9]+",                    "12345",            (char*) 5      },
+  { OK,  "\\D",                       "hej",              (char*) 1      },
+  { NOK, "\\d",                       "hej",              (char*) 0      },
+  { OK,  "[^\\w]",                    "\\",               (char*) 1      },
+  { OK,  "[\\W]",                     "\\",               (char*) 1      },
+  { NOK, "[\\w]",                     "\\",               (char*) 0      },
+  { OK,  "[^\\d]",                    "d",                (char*) 1      },
+  { NOK, "[\\d]",                     "d",                (char*) 0      },
+  { NOK, "[^\\D]",                    "d",                (char*) 0      },
+  { OK,  "[\\D]",                     "d",                (char*) 1      },
+  { OK,  "^.*\\\\.*$",                "c:\\Tools",        (char*) 8      },
+  { OK,  "^[\\+-]*[\\d]+$",           "+27",              (char*) 3      },
+  { OK,  "[abc]",                     "1c2",              (char*) 1      },
+  { NOK, "[abc]",                     "1C2",              (char*) 0      },
+  { OK,  "[1-5]+",                    "0123456789",       (char*) 5      },
+  { OK,  "[.2]",                      "1C2",              (char*) 1      },
+  { OK,  "a*$",                       "Xaa",              (char*) 2      },
+  { OK,  "a*$",                       "Xaa",              (char*) 2      },
+  { OK,  "[a-h]+",                    "abcdefghxxx",      (char*) 8      },
+  { NOK, "[a-h]+",                    "ABCDEFGH",         (char*) 0      },
+  { OK,  "[A-H]+",                    "ABCDEFGH",         (char*) 8      },
+  { NOK, "[A-H]+",                    "abcdefgh",         (char*) 0      },
+  { OK,  "[^\\s]+",                   "abc def",          (char*) 3      },
+  { OK,  "[^fc]+",                    "abc def",          (char*) 2      },
+  { OK,  "[^d\\sf]+",                 "abc def",          (char*) 3      },
+  { OK,  "\n",                        "abc\ndef",         (char*) 1      },
+  { OK,  "b.\\s*\n",                  "aa\r\nbb\r\ncc\r\n\r\n",(char*) 4      },
+  { OK,  ".*c",                       "abcabc",           (char*) 6      },
+  { OK,  ".+c",                       "abcabc",           (char*) 6      },
+  { OK,  "[b-z].*",                   "ab",               (char*) 1      },
+  { OK,  "b[k-z]*",                   "ab",               (char*) 1      },
+  { NOK, "[0-9]",                     "  - ",             (char*) 0      },
+  { OK,  "[^0-9]",                    "  - ",             (char*) 1      },
+  { OK,  "0|",                        "0|",               (char*) 2      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "0s:00:00",         (char*) 0      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "000:00",           (char*) 0      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "00:0000",          (char*) 0      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "100:0:00",         (char*) 0      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "00:100:00",        (char*) 0      },
+  { NOK, "\\d\\d:\\d\\d:\\d\\d",      "0:00:100",         (char*) 0      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:0:0",            (char*) 5      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:00:0",           (char*) 6      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:0:00",           (char*) 5      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:0:0",           (char*) 6      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:00:0",          (char*) 7      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:0:00",          (char*) 6      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "0:00:00",          (char*) 6      },
+  { OK,  "\\d\\d?:\\d\\d?:\\d\\d?",   "00:00:00",         (char*) 7      },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world !",    (char*) 12     },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "hello world !",    (char*) 12     },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello World !",    (char*) 12     },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world!   ",  (char*) 11     },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "Hello world  !",   (char*) 13     },
+  { OK,  "[Hh]ello [Ww]orld\\s*[!]?", "hello World    !", (char*) 15     },
+  { NOK, "\\d\\d?:\\d\\d?:\\d\\d?",   "a:0",              (char*) 0      }, /* Failing test case reported in https://github.com/kokke/tiny-regex-c/issues/12 */
 /*
-  { OK,  "[^\\w][^-1-4]",     ")T"          },
-  { OK,  "[^\\w][^-1-4]",     ")^"          },
-  { OK,  "[^\\w][^-1-4]",     "*)"          },
-  { OK,  "[^\\w][^-1-4]",     "!."          },
-  { OK,  "[^\\w][^-1-4]",     " x"          },
-  { OK,  "[^\\w][^-1-4]",     "$b"          },
+  { OK,  "[^\\w][^-1-4]",     ")T",          (char*) 2      },
+  { OK,  "[^\\w][^-1-4]",     ")^",          (char*) 2      },
+  { OK,  "[^\\w][^-1-4]",     "*)",          (char*) 2      },
+  { OK,  "[^\\w][^-1-4]",     "!.",          (char*) 2      },
+  { OK,  "[^\\w][^-1-4]",     " x",          (char*) 2      },
+  { OK,  "[^\\w][^-1-4]",     "$b",          (char*) 2      },
 */
-  { OK,  ".?bar",                      "real_bar"        },
-  { NOK, ".?bar",                      "real_foo"        },
-  { NOK, "X?Y",                        "Z"               },
+  { OK,  ".?bar",                      "real_bar",        (char*) 4      },
+  { NOK, ".?bar",                      "real_foo",        (char*) 0      },
+  { NOK, "X?Y",                        "Z",               (char*) 0      },
 };
 
 
@@ -97,6 +97,8 @@ int main()
     char* text;
     char* pattern;
     int should_fail;
+    int length;
+    int correctlen;
     size_t ntests = sizeof(test_vector) / sizeof(*test_vector);
     size_t nfailed = 0;
     size_t i;
@@ -106,8 +108,9 @@ int main()
         pattern = test_vector[i][1];
         text = test_vector[i][2];
         should_fail = (test_vector[i][0] == NOK);
+        correctlen = (int)(test_vector[i][3]);
 
-        int m = re_match(pattern, text);
+        int m = re_match(pattern, text, &length);
 
         if (should_fail)
         {
@@ -115,7 +118,7 @@ int main()
             {
                 printf("\n");
                 re_print(re_compile(pattern));
-                fprintf(stderr, "[%lu/%lu]: pattern '%s' matched '%s' unexpectedly. \n", (i+1), ntests, pattern, text);
+                fprintf(stderr, "[%lu/%lu]: pattern '%s' matched '%s' unexpectedly, matched %i chars. \n", (i+1), ntests, pattern, text, length);
                 nfailed += 1;
             }
         }
@@ -126,6 +129,11 @@ int main()
                 printf("\n");
                 re_print(re_compile(pattern));
                 fprintf(stderr, "[%lu/%lu]: pattern '%s' didn't match '%s' as expected. \n", (i+1), ntests, pattern, text);
+                nfailed += 1;
+            }
+            else if (length != correctlen)
+            {
+                fprintf(stderr, "[%lu/%lu]: pattern '%s' matched '%i' chars of '%s'; expected '%i'. \n", (i+1), ntests, pattern, length, text, correctlen);
                 nfailed += 1;
             }
         }

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -2065,6 +2065,7 @@ int main()
   const int ntests = 10;
   size_t bufsize = sizeof(buf) - 1;
   int i;
+  int dummy = 0;
   size_t bufsizes[ntests];
   char old;
 
@@ -2084,7 +2085,7 @@ int main()
 
     printf("  matching on %lu bytes of test input: ", bufsizes[i]);
     fflush(stdout);
-    printf("%d \n", re_match(".+nonexisting.+", buf)); 
+    printf("%d \n", re_match(".+nonexisting.+", buf, &dummy)); 
 
     buf[bufsizes[i]] = old;
   }

--- a/tests/test_rand.c
+++ b/tests/test_rand.c
@@ -13,9 +13,10 @@
 
 int main(int argc, char** argv)
 {
+  int length;
   if (argc == 3)
   {
-    int m = re_match(argv[1], argv[2]);
+    int m = re_match(argv[1], argv[2], &length);
     if (m != -1) 
       return 0;
   }

--- a/tests/test_rand_neg.c
+++ b/tests/test_rand_neg.c
@@ -15,9 +15,10 @@
 
 int main(int argc, char** argv)
 {
+  int length;
   if (argc == 3)
   {
-    int m = re_match(argv[1], argv[2]);
+    int m = re_match(argv[1], argv[2], &length);
     if (m == -1)
       return 0;
   }


### PR DESCRIPTION
Hello.

Thank you for this. It is simple and wonderful.

However, it was of limited utility for my use-case, because it could only report whether or not a match was found, and where. I needed to know how much text matched, as well, mainly so I could grab or skip the matching text.

But, because of how simple it was, I was able to open it and add this functionality.
Since it was useful to me, I am initiating a pull request, so others may see and use it.

This does change the API; an extra parameter must be passed to re_match and re_matchp:
```
int  re_matchp(re_t pattern, const char* text, int* matchlength);
int  re_match(const char* pattern, const char* text, int* matchlength);
```
This extra parameter is simply a pointer to an integer available to the caller; `re` will place the length of the match inside, no fuss.

I changed the benchmarks with the machine I had; I felt that was better than leaving them.

Timings also changed: internally, `+` and `*` weren't actually greedy; they didn't need to be, since `re` only needed to report whether or not the given position matched, but to report how much matched, that had to be fixed. This makes hungry nonmatching regexes a bit slower.

One last note is that `?` doesn't match if it doesn't have to. After all, the readme lists it as non-greedy. So, ending on `.?` will not include that final character in the count. Personally, I disagree with these semantics, but I left them unchanged.

Thanks for taking your time and maintaining this project.