### PR TITLE
Removed unnecessary check in ranges

### DIFF
--- a/re.c
+++ b/re.c
@@ -291,8 +291,8 @@ static int matchalphanum(char c)
 static int matchrange(char c, const char* str)
 {
   return ((c != '-') && (str[0] != '\0') && (str[0] != '-') &&
-         (str[1] == '-') && (str[1] != '\0') &&
-         (str[2] != '\0') && ((c >= str[0]) && (c <= str[2])));
+         (str[1] == '-') && (str[2] != '\0') && 
+         ((c >= str[0]) && (c <= str[2])));
 }
 static int ismetachar(char c)
 {


### PR DESCRIPTION
`(str[1] == '-') && (str[1] != '\0')` does not need to check if `str[1]` is NOT `'\0'`, since it already checked if it was a hyphen.