### PR TITLE
Support for multiple patterns

### DIFF
--- a/re.c
+++ b/re.c
@@ -71,7 +71,14 @@ static int ismetachar(char c);
 /* Public functions: */
 int re_match(const char* pattern, const char* text, int* matchlength)
 {
-  return re_matchp(re_compile(pattern), text, matchlength);
+  re_t re_p; /* pointer to (to be created) copy of compiled regex */
+  int ret = -1;
+
+  re_p = re_compile(pattern);
+  ret = re_matchp(re_p, text, matchlength);
+  free(re_p);
+
+  return (ret);
 }
 
 int re_matchp(re_t pattern, const char* text, int* matchlength)
@@ -113,6 +120,7 @@ re_t re_compile(const char* pattern)
   static regex_t re_compiled[MAX_REGEXP_OBJECTS];
   static unsigned char ccl_buf[MAX_CHAR_CLASS_LEN];
   int ccl_bufidx = 1;
+  re_t re_p; /* pointer to (to be created) copy of compiled regex in re_compiled */
 
   char c;     /* current char in pattern   */
   int i = 0;  /* index into pattern        */
@@ -238,7 +246,18 @@ re_t re_compile(const char* pattern)
   /* 'UNUSED' is a sentinel used to indicate end-of-pattern */
   re_compiled[j].type = UNUSED;
 
-  return (re_t) re_compiled;
+  re_p = (re_t)calloc(1, sizeof(re_compiled));
+  memcpy(re_p, re_compiled, sizeof(re_compiled));
+  return (re_t)re_p;
+}
+
+void re_freecompile(re_t pattern)
+{
+  if (pattern)
+  {
+    free(pattern);
+    pattern = NULL;
+  }
 }
 
 void re_print(regex_t* pattern)

--- a/re.h
+++ b/re.h
@@ -49,10 +49,11 @@ typedef struct regex_t* re_t;
 /* Compile regex string pattern to a regex_t-array. */
 re_t re_compile(const char* pattern);
 
-
 /* Find matches of the compiled pattern inside text. */
 int  re_matchp(re_t pattern, const char* text, int* matchlenght);
 
+/* Free memory of the compiled pattern */
+void re_freecompile(re_t pattern);
 
 /* Find matches of the txt pattern inside text (will compile automatically first). */
 int  re_match(const char* pattern, const char* text, int* matchlenght);


### PR DESCRIPTION
Support for multiple patterns

When multiple patterns are used simultaneously, the previous code will fail， example：

int match_length;
const char* string_to_search = "ahem.. 'hello world !' ..";

re_t  p1 = re_compile("[Hh]ello [Ww]orld\\s*[!]?");
re_t  p2 = re_compile("hello[0-9]");
re_t  p3 = re_compile("fadsf*");

int match_idx;
match_idx = re_matchp(p1, string_to_search, &match_length);
match_idx = re_matchp(p2, string_to_search, &match_length);
match_idx = re_matchp(p3, string_to_search, &match_length);

re_freecompile(p1);
re_freecompile(p2);
re_freecompile(p3);


