### PR TITLE
Create clib.json

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,12 @@
+{
+  "name": "tiny-regex-c",
+  "version": "0.1.0",
+  "repo": "kokke/tiny-regex-c",
+  "keywords": ["tiny", "regex", "pcre"],
+  "license": "Public Domain",
+  "makefile": "Makefile",
+  "src": [
+    "re.h",
+    "re.c"
+  ]
+}


### PR DESCRIPTION
This will allow folks to do:

```sh
$ clib install kokke/tiny-regex-c
```

into an existing [clib](https://github.com/clibs/clib) project