### PR TITLE
allow user to provide regex object storage

### DIFF
--- a/re.c
+++ b/re.c
@@ -35,8 +35,13 @@
 
 /* Definitions: */
 
+#ifndef MAX_REGEXP_OBJECTS
 #define MAX_REGEXP_OBJECTS      30    /* Max number of regex symbols in expression. */
+#endif
+
+#ifndef MAX_CHAR_CLASS_LEN
 #define MAX_CHAR_CLASS_LEN      40    /* Max length of character-class buffer in.   */
+#endif
 
 
 enum { UNUSED, DOT, BEGIN, END, QUESTIONMARK, STAR, PLUS, CHAR, CHAR_CLASS, INV_CHAR_CLASS, DIGIT, NOT_DIGIT, ALPHA, NOT_ALPHA, WHITESPACE, NOT_WHITESPACE, /* BRANCH */ };
@@ -111,8 +116,13 @@ re_t re_compile(const char* pattern)
   /* The sizes of the two static arrays below substantiates the static RAM usage of this module.
      MAX_REGEXP_OBJECTS is the max number of symbols in the expression.
      MAX_CHAR_CLASS_LEN determines the size of buffer for chars in all char-classes in the expression. */
-  static regex_t re_compiled[MAX_REGEXP_OBJECTS];
-  static unsigned char ccl_buf[MAX_CHAR_CLASS_LEN];
+  static regex_t static_objects[MAX_REGEXP_OBJECTS];
+  static unsigned char static_ccl_buf[MAX_CHAR_CLASS_LEN];
+  return re_compile_to(pattern, static_objects, static_ccl_buf);
+}
+
+re_t re_compile_to(const char* pattern, regex_t *re_compiled, unsigned char *ccl_buf)
+{
   int ccl_bufidx = 1;
 
   char c;     /* current char in pattern   */

--- a/re.h
+++ b/re.h
@@ -46,9 +46,11 @@ extern "C"{
 typedef struct regex_t* re_t;
 
 
-/* Compile regex string pattern to a regex_t-array. */
+/* Compile regex string pattern to a static regex_t-array. */
 re_t re_compile(const char* pattern);
 
+/* Compile regex string pattern to the given regex_t-array. */
+re_t re_compile_to(const char* pattern, re_t objects, unsigned char *ccl_buf);
 
 /* Find matches of the compiled pattern inside text. */
 int re_matchp(re_t pattern, const char* text, int* matchlength);


### PR DESCRIPTION
I've added a new function `re_compile_to` that takes a pointer to an array of objects and characters.  This allows a user to specify their own storage for their regex objects. This way a user can compile multiple regex objects and keep them around if they so choose.  At the same time this also means that the user will need to know the value of `MAX_REGEXP_OBJECTS` and `MAX_CHAR_CLASSLEN`, so I made those configurable by putting them inside their own `#ifdef`s.  This way a user can customize them with `-DMAX_REGEXP_OBJECTS=XXX` and `-DMAX_CHAR_CLASS_LEN=YYY`.