### PR TITLE
fix python regex test scripts

### DIFF
--- a/scripts/regex_test.py
+++ b/scripts/regex_test.py
@@ -58,7 +58,7 @@ while repeats >= 0:
     repeats -= 1
     example = exrex.getone(pattern)
     #print("%s %s %s" % (prog, pattern, example))
-    ret = call([prog, "\"%s\"" % pattern, "\"%s\"" % example])
+    ret = call([prog, pattern, example])
     if ret != 0:
       escaped = repr(example) # escapes special chars for better printing
       print("    FAIL : doesn't match %s as expected [%s]." % (escaped, ", ".join([("0x%02x" % ord(e)) for e in example]) ))

--- a/scripts/regex_test_neg.py
+++ b/scripts/regex_test_neg.py
@@ -64,7 +64,7 @@ while repeats >= 0:
     repeats -= 1
     example = gen_no_match(pattern)
     #print("%s %s %s" % (prog, pattern, example))
-    ret = call([prog, "\"%s\"" % pattern, "\"%s\"" % example])
+    ret = call([prog, pattern, example])
     if ret != 0:
       escaped = repr(example) # escapes special chars for better printing
       print("    FAIL : matches %s unexpectedly [%s]." % (escaped, ", ".join([("0x%02x" % ord(e)) for e in example]) ))


### PR DESCRIPTION
In python, when you pass an array to `call`, the arguments are not to be quoted unless you are intending on passing the quotes to the underlying command you are running.  In this case the the underlying programs "test_rand.c" and "test_rand_neg.c" are not expecting their arguments to be quoted, but instead, are expecting them to be unquoted regular expression strings.  This is a common mistake because people confuse the BASH syntax for escaping characters with the strings passed to a subprocess in Python.