### PR TITLE
improve Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.swp
 *.pyc
-/tests/*
-!/tests/*.c
+/bin

--- a/scripts/regex_test.py
+++ b/scripts/regex_test.py
@@ -3,7 +3,7 @@
 """
   This program generates random text that matches a given regex-pattern.
   The pattern is given via sys.argv and the generated text is passed to
-  the binary 'tests/test_rand' to check if the generated text also matches
+  the binary 'bin/test_rand' to check if the generated text also matches
   the regex-pattern in the C implementation.
   The exit-code of the testing program, is used to determine test success.
 
@@ -17,7 +17,7 @@ import exrex
 from subprocess import call
 
 
-prog = "./tests/test_rand"
+prog = "./bin/test_rand"
 
 if len(sys.argv) < 2:
   print("")

--- a/scripts/regex_test_neg.py
+++ b/scripts/regex_test_neg.py
@@ -3,7 +3,7 @@
 """
   This program generates random text that matches a given regex-pattern.
   The pattern is given via sys.argv and the generated text is passed to
-  the binary 'tests/test_rand' to check if the generated text also matches
+  the binary 'bin/test_rand_neg' to check if the generated text also matches
   the regex-pattern in the C implementation.
   The exit-code of the testing program, is used to determine test success.
 
@@ -18,7 +18,7 @@ import random
 from subprocess import call
 
 
-prog = "./tests/test_rand_neg"
+prog = "./bin/test_rand_neg"
 
 if len(sys.argv) < 2:
   print("")


### PR DESCRIPTION
Here are a list of the improvements done to the Makefile.

1. allow tests to be built and run individually from the command-line:

Examples of building individual tests:
```
make bin/test1
make bin/test2
...
```

Running individual tests:
```sh
make test1
make test2
make test_compile
make test_rand
make test_rand_neg

# note: you can still run all the tests with
make test
```

2. Because building and running the tests are now in their own rules, the user can run them in parallel now:

Build everything in parallel with 5 threads:
```
make -j5
```

Build and run everything with 5 threads:
```
make -j5 test
```

3. Moved all outputs to the "bin" directory

This simplifies the code in the "clean" target to 1 command. It also simplifies the .gitignore file and make it easy for developers to distinguish between output files and source files.

4. Added re.c as a dependency to all the tests

Now if the user modifies re.c, all the tests will be see that they need to be rebuilt.