### PR TITLE
Move CC out of Makefile, and clean some compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# Compiler to use - can be replaced by clang for instance
-CC := gcc
-
 # Number of random text expressions to generate, for random testing
 NRAND_TESTS := 1000
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The main design goal of this library is to be small, correct, self contained and
 - Verification-harness for [KLEE Symbolic Execution Engine](https://klee.github.io), see [formal verification.md](https://github.com/kokke/tiny-regex-c/blob/master/formal_verification.md).
 - Provides character length of matches.
 - Compiled for x86 using GCC 7.2.0 and optimizing for size, the binary takes up ~2-3kb code space and allocates ~0.5kb RAM :
+- Compile with clang by adding make parameter(make clean; make CC=clang)
   ```
   > gcc -Os -c re.c
   > size re.o

--- a/tests/test1.c
+++ b/tests/test1.c
@@ -110,7 +110,7 @@ int main()
         pattern = test_vector[i][1];
         text = test_vector[i][2];
         should_fail = (test_vector[i][0] == NOK);
-        correctlen = (int)(test_vector[i][3]);
+        correctlen = (int)(long)(test_vector[i][3]);
 
         int m = re_match(pattern, text, &length);
 
@@ -120,7 +120,7 @@ int main()
             {
                 printf("\n");
                 re_print(re_compile(pattern));
-                fprintf(stderr, "[%lu/%lu]: pattern '%s' matched '%s' unexpectedly, matched %i chars. \n", (i+1), ntests, pattern, text, length);
+                fprintf(stderr, "[%zu/%zu]: pattern '%s' matched '%s' unexpectedly, matched %i chars. \n", (i+1), ntests, pattern, text, length);
                 nfailed += 1;
             }
         }
@@ -130,19 +130,19 @@ int main()
             {
                 printf("\n");
                 re_print(re_compile(pattern));
-                fprintf(stderr, "[%lu/%lu]: pattern '%s' didn't match '%s' as expected. \n", (i+1), ntests, pattern, text);
+                fprintf(stderr, "[%zu/%zu]: pattern '%s' didn't match '%s' as expected. \n", (i+1), ntests, pattern, text);
                 nfailed += 1;
             }
             else if (length != correctlen)
             {
-                fprintf(stderr, "[%lu/%lu]: pattern '%s' matched '%i' chars of '%s'; expected '%i'. \n", (i+1), ntests, pattern, length, text, correctlen);
+                fprintf(stderr, "[%zu/%zu]: pattern '%s' matched '%i' chars of '%s'; expected '%i'. \n", (i+1), ntests, pattern, length, text, correctlen);
                 nfailed += 1;
             }
         }
     }
 
     // printf("\n");
-    printf("%lu/%lu tests succeeded.\n", ntests - nfailed, ntests);
+    printf("%zu/%zu tests succeeded.\n", ntests - nfailed, ntests);
     printf("\n");
     printf("\n");
     printf("\n");

--- a/tests/test2.c
+++ b/tests/test2.c
@@ -2083,7 +2083,7 @@ int main()
     old = buf[bufsizes[i]];
     buf[bufsizes[i]] = 0;
 
-    printf("  matching on %lu bytes of test input: ", bufsizes[i]);
+    printf("  matching on %zu bytes of test input: ", bufsizes[i]);
     fflush(stdout);
     printf("%d \n", re_match(".+nonexisting.+", buf, &dummy));
 


### PR DESCRIPTION
1.  Move compiler change feature from Makefile variable to make parameter.
2. Fix compiler warnings.