### PR TITLE
re.c: fix recursive call arguments and set CC optionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Compiler to use - can be replaced by clang for instance
-CC := gcc
+CC ?= gcc
 
 # Number of random text expressions to generate, for random testing
 NRAND_TESTS := 1000

--- a/re.c
+++ b/re.c
@@ -478,7 +478,7 @@ static int matchpattern(regex_t* pattern, const char* text, int *matchlength)
   else if ((text[0] != '\0') && matchone(pattern[0], text[0]))
   {
     (*matchlength)++;
-    return matchpattern(&pattern[1], text+1);
+    return matchpattern(&pattern[1], text+1, matchlength);
   }
   else
   {


### PR DESCRIPTION
When calling the recursive varient of matchpattern, it doesn't call the function with the matchlength argument. This patch fixes it.

Also, set Makefile CC to gcc when GNU/make can't find the default CC path. This fixes compilation on other Unix-like platforms (e.g. *BSDs) where CC defaults to clang (we previously explicitly set this to GCC).